### PR TITLE
All `RUN` commands were joined in order to minimize the layers size.

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -33,48 +33,40 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-# Basic Linux tools
-RUN apt-get update
-RUN apt-get install -y wget bcrypt curl
-RUN apt-get install -y unzip zip
-RUN apt-get install -y gnupg gnupg2
-RUN apt-get install -y bsdmainutils
-RUN apt-get install -y libxml2-utils
-RUN apt-get install -y build-essential
-RUN apt-get install -y automake autoconf
-
-# Git 2.0
-RUN apt-get install -y software-properties-common python-software-properties
-RUN add-apt-repository ppa:git-core/ppa
-RUN apt-get update
-RUN apt-get install -y git git-core
-
-# Ruby
-RUN apt-get update && apt-get install -y ruby-dev libmagic-dev=1:5.14-2ubuntu3.3 \
-  zlib1g-dev=1:1.2.8.dfsg-1ubuntu1
-RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
-RUN curl -L https://get.rvm.io | bash -s stable
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.3.3"
-RUN /bin/bash -l -c "gem update && gem install --no-ri --no-rdoc nokogiri:1.6.7.2 bundler:1.11.2"
-
-# PHP
-RUN apt-get install -y php5 php5-dev php-pear
-
-# Java
-RUN apt-get install -y default-jdk
-
-# S3cmd for AWS S3 integration
-RUN apt-get install -y s3cmd
-
-# MySQL client
-RUN apt-get install -y mysql-client
-
-# NodeJS
-RUN rm -rf /usr/lib/node_modules
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y nodejs
-
-# Clean up
-RUN rm -rf /tmp/*
-RUN rm -rf /root/.ssh
+RUN apt-get update \
+    # Basic Linux tools
+    && apt-get install -y wget bcrypt curl \
+    && apt-get install -y unzip zip \
+    && apt-get install -y gnupg gnupg2 \
+    && apt-get install -y bsdmainutils \
+    && apt-get install -y libxml2-utils \
+    && apt-get install -y build-essential \
+    && apt-get install -y automake autoconf \
+    # Git 2.0
+    && apt-get install -y software-properties-common python-software-properties \
+    && add-apt-repository ppa:git-core/ppa \
+    && apt-get update \
+    && apt-get install -y git git-core \
+    # Ruby
+    && apt-get update \
+    && apt-get install -y ruby-dev libmagic-dev=1:5.14-2ubuntu3.3 zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
+    && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 \
+    && curl -L https://get.rvm.io | bash -s stable \
+    && /bin/bash -l -c "rvm requirements" \
+    && /bin/bash -l -c "rvm install 2.3.3" \
+    && /bin/bash -l -c "gem update && gem install --no-ri --no-rdoc nokogiri:1.6.7.2 bundler:1.11.2" \
+    # PHP
+    && apt-get install -y php5 php5-dev php-pear \
+    # Java
+    && apt-get install -y default-jdk \
+    # S3cmd for AWS S3 integration
+    && apt-get install -y s3cmd \
+    # MySQL client
+    && apt-get install -y mysql-client \
+    # NodeJS
+    && rm -rf /usr/lib/node_modules \
+    && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && apt-get install -y nodejs \
+    # Clean up
+    && rm -rf /tmp/* \
+    && rm -rf /root/.ssh

--- a/src/docker/readme.md
+++ b/src/docker/readme.md
@@ -1,0 +1,2 @@
+### Docker installation
+ - [Windows OS](https://github.com/dgroup/docker-on-windows)


### PR DESCRIPTION
During docker image building procedure you may observe warning 
`[WARNING]: Empty continuation line found`.

It happens due to comments between multiple commands in the `RUN` statement.
The fix is quite simple - remove the comments.
From my points of view these comments are useful, thus I kept them as is.

That's a docker bug, nothing critical just a warning, see more details here -  https://github.com/moby/moby/pull/35004.

Could you, please, add me as a contributor?
Email: `dgroup@ex.ua`
