### PR TITLE
Ssh tunnel example to connect to mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ mysqldump --lock-tables=false --host=www.example.com \
   --user=username --password=password \
   --databases dbname > mysql.sql
 ```
+Since this would require to open your mysql port to the internet, which is not advisable from a security perspective, you should probably use a ssh tunnel:
+
+```bash
+cat > file.key <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+<your ssh private key here>
+-----END RSA PRIVATE KEY-----
+EOT
+chmod 700 file.key
+ssh -Nf -i file.key -L3306:localhost:3306 your_user@www.example.com
+rm file.key
+```
+and then connect with the above script:
+
+```bash
+mysqldump --lock-tables=false --host=localhost ...same as above
+```
 
 To download an entire FTP directory use [wget](https://www.gnu.org/software/wget/):
 


### PR DESCRIPTION
If local port forwarding is allowed on the server and you're allowed to write a file to the local file system, it would be possible to connect securely to mysql using a ssh tunnel, without exposing port 3306 on the internet.
I assume that the script is run on a throw away container; otherwise this will require some cleanup at the end by killing the ssh process once done.