### PR TITLE
Readme file ThreeCopies logo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="http://www.threecopies.com/images/logo.png" width="64px" height="64px"/>
+<img src="src/main/resources/images/logo.png" width="64px" height="64px" alt="ThreeCopies logo"/>
 
 [![Managed by Zerocracy](http://www.0crat.com/badge/C3RFVLU72.svg)](http://www.0crat.com/p/C3RFVLU72)
 [![DevOps By Rultor.com](http://www.rultor.com/b/yegor256/threecopies)](http://www.rultor.com/p/yegor256/threecopies)


### PR DESCRIPTION
Minor change on README to fix the broken logo. Using the relative path to logo.png image on the repo.