### PR TITLE
#16 paginate the logs page in chunks of twenty

### DIFF
--- a/src/main/java/com/threecopies/tk/TkLogs.java
+++ b/src/main/java/com/threecopies/tk/TkLogs.java
@@ -25,14 +25,18 @@ package com.threecopies.tk;
 import com.jcabi.aspects.Tv;
 import com.threecopies.base.Base;
 import java.io.IOException;
+import java.util.List;
 import org.cactoos.iterable.HeadOf;
 import org.cactoos.iterable.Joined;
+import org.cactoos.iterable.Skipped;
 import org.cactoos.list.ListOf;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
+import org.takes.rq.RqHref;
 import org.takes.rs.xe.XeAppend;
 import org.takes.rs.xe.XeDirectives;
+import org.xembly.Directive;
 import org.xembly.Directives;
 
 /**
@@ -61,21 +65,39 @@ final class TkLogs implements Take {
 
     @Override
     public Response act(final Request request) throws IOException {
+        final int page = Math.max(
+            1,
+            Integer.parseInt(
+                new RqHref.Smart(request).single("page", "1")
+            )
+        );
+        final List<Iterable<Directive>> items = new ListOf<>(
+            new HeadOf<>(
+                Tv.TWENTY,
+                new Skipped<>(
+                    (page - 1) * Tv.TWENTY,
+                    new RqUser(this.base, request).logs()
+                )
+            )
+        );
+        final Directives paging = new Directives().add("paging")
+            .add("current").set(Integer.toString(page)).up();
+        if (page > 1) {
+            paging.add("prev").set(Integer.toString(page - 1)).up();
+        }
+        if (items.size() == Tv.TWENTY) {
+            paging.add("next").set(Integer.toString(page + 1)).up();
+        }
+        paging.up();
         return new RsPage(
             "/xsl/logs.xsl",
             request,
             () -> new ListOf<>(
                 new XeAppend("menu", "logs"),
                 new XeDirectives(
-                    new Directives().add("logs").append(
-                        new Joined<>(
-                            new HeadOf<>(
-                                Tv.TWENTY,
-                                new RqUser(this.base, request).logs()
-                            )
-                        )
-                    )
-                )
+                    new Directives().add("logs").append(new Joined<>(items))
+                ),
+                new XeDirectives(paging)
             )
         );
     }

--- a/src/main/xsl/logs.xsl
+++ b/src/main/xsl/logs.xsl
@@ -70,8 +70,24 @@ software.
         <xsl:apply-templates select="log"/>
       </tbody>
     </table>
+    <xsl:apply-templates select="/page/paging"/>
+  </xsl:template>
+  <xsl:template match="paging">
     <p>
-      <xsl:text>Most probably there is more, but paging is not implemented yet :(</xsl:text>
+      <xsl:if test="prev">
+        <a href="?page={prev}">
+          <xsl:text>&lt; prev</xsl:text>
+        </a>
+        <xsl:text> </xsl:text>
+      </xsl:if>
+      <xsl:text>page </xsl:text>
+      <xsl:value-of select="current"/>
+      <xsl:if test="next">
+        <xsl:text> </xsl:text>
+        <a href="?page={next}">
+          <xsl:text>next &gt;</xsl:text>
+        </a>
+      </xsl:if>
     </p>
   </xsl:template>
   <xsl:template match="log">


### PR DESCRIPTION
Closes #16. The logs page used to truncate to the first twenty rows and tell the visitor in prose that paging was not implemented. This change wires `?page=N` through `TkLogs`, advances the underlying iterator by `(N - 1) * 20` rows, and renders the current twenty.

The XSL template `logs.xsl` now consumes a `<paging>` block from the page model: when the previous page exists it renders a `prev` link, when twenty rows came back it renders a `next` link, and either way it shows the current page number. The placeholder paragraph that announced the missing feature is gone.

Local checks: `mvn --batch-mode -Pqulice verify -DskipTests` was run on the branch and reported `BUILD SUCCESS` with `Qulice quality check completed in 26s`. `mvn --batch-mode test` runs the full surefire suite; the single pre-existing failure in `TkAppTest#rendersHomePageViaHttp` reproduces unmodified on `master` and is unrelated to this change.
